### PR TITLE
Show visual error markers for every error found on recompile()

### DIFF
--- a/errormarkers.py
+++ b/errormarkers.py
@@ -10,7 +10,6 @@ WARNING = "warning"
 
 
 def clear_error_marks():
-    '''Adds lint marks to view.'''
     global ERRORS, WARNINGS
 
     listdict = lambda: defaultdict(list)

--- a/errormarkers.py
+++ b/errormarkers.py
@@ -1,0 +1,106 @@
+import sublime
+import sublime_plugin
+from collections import defaultdict
+
+ERRORS = {}
+WARNINGS = {}
+
+ERROR = "error"
+WARNING = "warning"
+
+
+def clear_error_marks():
+    '''Adds lint marks to view.'''
+    global ERRORS, WARNINGS, VIOLATIONS
+
+    listdict = lambda: defaultdict(list)
+    ERRORS = defaultdict(listdict)
+    WARNINGS = defaultdict(listdict)
+    VIOLATIONS = defaultdict(listdict)
+
+
+def add_error_mark(severity, filename, line, message):
+    if severity.lower() == ERROR:
+        ERRORS[filename][line].append(message)
+    else:
+        WARNINGS[filename][line].append(message)
+
+
+def show_error_marks(view):
+    '''Adds error marks to view.'''
+    erase_error_marks(view)
+    fill_outlines = False
+    gutter_mark = 'dot'
+    outlines = {'warning': [], 'violation': [], 'illegal': []}
+    fn = view.file_name()
+
+    for line in ERRORS[fn].keys():
+        outlines['illegal'].append(view.full_line(view.text_point(line, 0)))
+    for line in WARNINGS[fn].keys():
+        outlines['warning'].append(view.full_line(view.text_point(line, 0)))
+
+    for lint_type in outlines:
+        if outlines[lint_type]:
+            args = [
+                'sublimeclang-outlines-{0}'.format(lint_type),
+                outlines[lint_type],
+                'invalid.{0}'.format(lint_type),
+                gutter_mark
+            ]
+            if not fill_outlines:
+                args.append(sublime.DRAW_OUTLINED)
+            view.add_regions(*args)
+
+
+def erase_error_marks(view):
+    '''erase all error marks from view'''
+    view.erase_regions('sublimeclang-outlines-illegal')
+    view.erase_regions('sublimeclang-outlines-violation')
+    view.erase_regions('sublimeclang-outlines-warning')
+
+
+def last_selected_lineno(view):
+    return view.rowcol(view.sel()[0].end())[0]
+
+
+def update_statusbar(view):
+    fn = view.file_name()
+    lineno = last_selected_lineno(view)
+
+    if fn in ERRORS and lineno in ERRORS[fn]:
+        view.set_status('SublimeClang', '; '.join(ERRORS[fn][lineno]))
+    elif fn in WARNINGS and lineno in WARNINGS[fn]:
+        view.set_status('SublimeClang', '; '.join(WARNINGS[fn][lineno]))
+    else:
+        view.erase_status('SublimeClang')
+
+
+class SublimeClangStatusbarUpdater(sublime_plugin.EventListener):
+    '''This plugin controls a linter meant to work in the background
+    to provide interactive feedback as a file is edited. It can be
+    turned off via a setting.
+    '''
+
+    def __init__(self):
+        super(SublimeClangStatusbarUpdater, self).__init__()
+        self.lastSelectedLineNo = -1
+
+    def is_enabled(self):
+        return True
+
+    def on_selection_modified(self, view):
+        if view.is_scratch():
+            return
+
+        # We only display errors in the status bar for the last line in the current selection.
+        # If that line number has not changed, there is no point in updating the status bar.
+        lastSelectedLineNo = last_selected_lineno(view)
+
+        if lastSelectedLineNo != self.lastSelectedLineNo:
+            self.lastSelectedLineNo = lastSelectedLineNo
+            update_statusbar(view)
+
+    def on_activated(self, view):
+        fn = view.file_name()
+        if fn in ERRORS or fn in WARNINGS:
+            show_error_marks(view)

--- a/errormarkers.py
+++ b/errormarkers.py
@@ -11,12 +11,11 @@ WARNING = "warning"
 
 def clear_error_marks():
     '''Adds lint marks to view.'''
-    global ERRORS, WARNINGS, VIOLATIONS
+    global ERRORS, WARNINGS
 
     listdict = lambda: defaultdict(list)
     ERRORS = defaultdict(listdict)
     WARNINGS = defaultdict(listdict)
-    VIOLATIONS = defaultdict(listdict)
 
 
 def add_error_mark(severity, filename, line, message):
@@ -31,7 +30,7 @@ def show_error_marks(view):
     erase_error_marks(view)
     fill_outlines = False
     gutter_mark = 'dot'
-    outlines = {'warning': [], 'violation': [], 'illegal': []}
+    outlines = {'warning': [], 'illegal': []}
     fn = view.file_name()
 
     for line in ERRORS[fn].keys():
@@ -55,7 +54,6 @@ def show_error_marks(view):
 def erase_error_marks(view):
     '''erase all error marks from view'''
     view.erase_regions('sublimeclang-outlines-illegal')
-    view.erase_regions('sublimeclang-outlines-violation')
     view.erase_regions('sublimeclang-outlines-warning')
 
 
@@ -76,9 +74,8 @@ def update_statusbar(view):
 
 
 class SublimeClangStatusbarUpdater(sublime_plugin.EventListener):
-    '''This plugin controls a linter meant to work in the background
-    to provide interactive feedback as a file is edited. It can be
-    turned off via a setting.
+    ''' This EventListener will show the error messages for the current
+    line in the statusbar when the current line changes.
     '''
 
     def __init__(self):

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -29,6 +29,8 @@ from errormarkers import clear_error_marks, add_error_mark, show_error_marks
 
 translationUnits = {}
 index = None
+
+
 class SublimeClangAutoComplete(sublime_plugin.EventListener):
     def __init__(self):
         s = sublime.load_settings("clang.sublime-settings")
@@ -38,13 +40,13 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
         self.recompile_active = False
         self.auto_complete_active = False
 
-    def load_settings(self, s = None):
+    def load_settings(self, s=None):
         global translationUnits
         translationUnits.clear()
         if s == None:
             s = sublime.load_settings("clang.sublime-settings")
         self.popupDelay = s.get("popupDelay", 500)
-        self.dont_complete_startswith = s.get("dont_complete_startswith", ['operator','~'])
+        self.dont_complete_startswith = s.get("dont_complete_startswith", ['operator', '~'])
         self.recompileDelay = s.get("recompileDelay", 1000)
         self.hide_clang_output = s.get("hide_output_when_empty", False)
         self.add_language_option = s.get("add_language_option", True)
@@ -54,7 +56,7 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
         representation = ""
         insertion = ""
         returnType = ""
-        start = False;
+        start = False
         placeHolderCount = 0
         for chunk in compRes.string:
             if chunk.isKindTypedText():
@@ -139,12 +141,12 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
         tu = self.get_translation_unit(view.file_name())
         if tu == None:
             return []
-        row,col = view.rowcol(locations[0]-len(prefix)) # Getting strange results form clang if I don't remove prefix
+        row, col = view.rowcol(locations[0] - len(prefix))  # Getting strange results form clang if I don't remove prefix
         unsaved_files = []
         if view.is_dirty():
             unsaved_files.append((view.file_name(), str(view.substr(Region(0, view.size())))))
 
-        res = tu.codeComplete(view.file_name(), row+1, col+1, unsaved_files, 3)
+        res = tu.codeComplete(view.file_name(), row + 1, col + 1, unsaved_files, 3)
         ret = []
         if res != None:
             #for diag in res.diagnostics:

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -25,6 +25,7 @@ import sublime_plugin
 from sublime import Region
 import sublime
 import re
+from errormarkers import clear_error_marks, add_error_mark, show_error_marks
 
 translationUnits = {}
 index = None
@@ -177,6 +178,7 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
         tu.reparse(unsaved_files)
         errString = ""
         show = False
+        clear_error_marks()  # clear visual error marks
         if len(tu.diagnostics):
             errString = ""
             for diag in tu.diagnostics:
@@ -193,6 +195,8 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
                 for fix in diag.fixits:
                     errString = "%s%s\n" % (errString, fix)
                 """
+                add_error_mark(
+                    diag.severityName, filename, f.line - 1, diag.spelling)  # clear visual error marks
             show = True
         v = view.window().get_output_panel("clang")
         v.settings().set("result_file_regex", "^(...*?):([0-9]*):?([0-9]*)")
@@ -204,6 +208,7 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
         v.insert(e, 0, errString)
         v.end_edit(e)
         v.set_read_only(True)
+        show_error_marks(view)
         if show:
             view.window().run_command("show_panel", {"panel": "output.clang"})
         elif self.hide_clang_output:

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -142,7 +142,7 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
         row,col = view.rowcol(locations[0]-len(prefix)) # Getting strange results form clang if I don't remove prefix
         unsaved_files = []
         if view.is_dirty():
-            unsaved_files.append((view.file_name(), str(view.substr(Region(0, 65536)))))
+            unsaved_files.append((view.file_name(), str(view.substr(Region(0, view.size())))))
 
         res = tu.codeComplete(view.file_name(), row+1, col+1, unsaved_files, 3)
         ret = []
@@ -173,7 +173,7 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
 
     def recompile(self):
         view = self.view
-        unsaved_files = [(view.file_name(), view.substr(Region(0, 65536)))]
+        unsaved_files = [(view.file_name(), view.substr(Region(0, view.size())))]
         tu = self.get_translation_unit(view.file_name())
         tu.reparse(unsaved_files)
         errString = ""


### PR DESCRIPTION
Hi,

I just forked your SublimeClang plugin and added visual error markers for my own use. 
They are refreshed on every call to recompile(), and highlight the lines with errors and warning. Also, the statusbar will show the error message for the currently selected line.

Maybe you are interested in this feature. Also, maybe there should be an option in the settings file to turn these markers off, if you want to incude this feature into your version of SublimeClang.

Again, great plugin!
Julian
