### PR TITLE
Draw outline around the error message 

### DIFF
--- a/errormarkers.py
+++ b/errormarkers.py
@@ -7,7 +7,23 @@ WARNINGS = {}
 
 ERROR = "error"
 WARNING = "warning"
+clang_view = None
 
+def set_clang_view(view):
+    global clang_view
+    clang_view = view
+
+def highlight_panel_row():
+    v = clang_view
+    view = sublime.active_window().active_view()
+    row, col = view.rowcol(view.sel()[0].a)
+    str = "%s:%d" % (view.file_name(), (row + 1))
+    r = v.find(str, 0)
+    if r == None:
+	v.erase_regions('highlightText')
+    else:
+        regions = [v.full_line(r)]
+        v.add_regions('highlightText', regions, 'string', 'dot', sublime.DRAW_OUTLINED)
 
 def clear_error_marks():
     global ERRORS, WARNINGS
@@ -97,6 +113,7 @@ class SublimeClangStatusbarUpdater(sublime_plugin.EventListener):
         if lastSelectedLineNo != self.lastSelectedLineNo:
             self.lastSelectedLineNo = lastSelectedLineNo
             update_statusbar(view)
+            highlight_panel_row()
 
     def has_errors(self, view):
         fn = view.file_name()

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -40,7 +40,7 @@ import threading
 import time
 import Queue
 from errormarkers import clear_error_marks, add_error_mark, show_error_marks, \
-                         update_statusbar, erase_error_marks
+                         update_statusbar, erase_error_marks, set_clang_view
 
 language_regex = re.compile("(?<=source\.)[\w+#]+")
 
@@ -543,6 +543,7 @@ def display_compilation_results(view):
         v = view.window().get_output_panel("clang")
         v.settings().set("result_file_regex", "^(.+):([0-9]+),([0-9]+)")
         view.window().get_output_panel("clang")
+	set_clang_view(v)
         v.set_read_only(False)
         v.set_scratch(True)
         v.set_name("sublimeclang.%s" % view.file_name())


### PR DESCRIPTION
First python attempt. Draw outline around the error message in the clang ouput panel when the cursor is positioned on an error in the source. Good for when there are LOTS of warnings/errors.
