### PR TITLE
Added replacement of ${home} ${project_path:} and ${folder:} tokens in the configuration values. 

### DIFF
--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -40,7 +40,7 @@ import threading
 import time
 from errormarkers import clear_error_marks, add_error_mark, show_error_marks, \
                          update_statusbar, erase_error_marks, set_clang_view
-from common import get_setting, get_settings, Worker
+from common import get_setting, get_settings, get_path_setting, Worker
 
 language_regex = re.compile("(?<=source\.)[\w+#]+")
 
@@ -224,7 +224,7 @@ class TranslationUnitCache(Worker):
         self.parsingList.unlock()
 
     def get_opts(self, view):
-        opts = get_setting("options")
+        opts = get_path_setting("options")
         if get_setting("add_language_option", True):
             language = get_language(view)
             if language == "objc":


### PR DESCRIPTION
${home} is replaced with the value of the HOME environment variable.

${project_path:<file>} tries to find a file with the given name in all the registered project folders and
returns the first file found, or the original file name if none is found.
Example: ${project_path:project.sublime-project} tries to find a file named "project.sublime-project" relative
to the current project's folders. If none is found, it is replaced with "project.sublime-project".

${folder:<file>} is replaced with the dirname of the given path.
Example: ${folder:/path/to/file} is replaced with "/path/to".

Replacement is done sequencially, first all ${home} tokens, then all ${project_path:} are resolved, and then the
${folder:} are replaced.
## 

This allows users to have include paths relative to the project location, and solves the problem of updating the settings if the project location changes.
