### PR TITLE
Add detail to the diagnostic errors to show which -W option disables it

### DIFF
--- a/clang/cindex.py
+++ b/clang/cindex.py
@@ -243,6 +243,12 @@ class Diagnostic(object):
         return _clang_getDiagnosticSpelling(self)
 
     @property
+    def disable_option(self):
+        option = _CXString()
+        _clang_getDiagnosticOption(self, byref(option))
+        return _CXString_getCString(option)
+
+    @property
     def ranges(self):
         class RangeIterator:
             def __init__(self, diag):
@@ -1233,6 +1239,11 @@ _clang_disposeDiagnostic.argtypes = [Diagnostic]
 _clang_getDiagnosticSeverity = lib.clang_getDiagnosticSeverity
 _clang_getDiagnosticSeverity.argtypes = [Diagnostic]
 _clang_getDiagnosticSeverity.restype = c_int
+
+_clang_getDiagnosticOption = lib.clang_getDiagnosticOption
+_clang_getDiagnosticOption.argtypes = [Diagnostic, POINTER(_CXString)]
+_clang_getDiagnosticOption.restype = _CXString
+_clang_getDiagnosticOption.errcheck = _CXString.from_result
 
 _clang_getDiagnosticLocation = lib.clang_getDiagnosticLocation
 _clang_getDiagnosticLocation.argtypes = [Diagnostic]

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -553,6 +553,8 @@ def display_compilation_results(view):
                 err = "%s:%d,%d - %s - %s" % (filename, f.line, f.column,
                                               diag.severityName,
                                               diag.spelling)
+                if len(diag.disable_option) > 0:
+                    err = "%s [Disable with %s]" % (err, diag.disable_option)
                 if diag.severity == cindex.Diagnostic.Fatal and \
                         "not found" in diag.spelling:
                     err = "%s\nDid you configure the include path used by clang properly?\n" \


### PR DESCRIPTION
e.g. 

`Warning - expression result unused [Disable with -Wno-unused-value]`
