### PR TITLE
Sometimes diag.disable_option is missing, so it will display clang errors even when this attribute is missing.

### DIFF
--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -555,8 +555,11 @@ def display_compilation_results(view):
                 err = "%s:%d,%d - %s - %s" % (filename, f.line, f.column,
                                               diag.severityName,
                                               diag.spelling)
-                if len(diag.disable_option) > 0:
-                    err = "%s [Disable with %s]" % (err, diag.disable_option)
+                try:
+                    if len(diag.disable_option) > 0:
+                        err = "%s [Disable with %s]" % (err, diag.disable_option)
+                except AttributeError:
+                    pass
                 if diag.severity == cindex.Diagnostic.Fatal and \
                         "not found" in diag.spelling:
                     err = "%s\nDid you configure the include path used by clang properly?\n" \


### PR DESCRIPTION
Sometimes diag.disable_option is missing, so i added a try except around it. So it will continue to display and highlight errors when the the "disable_option" attribute is missing.
