### PR TITLE
Add notes to the README regarding completion speed improvements.

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -51,6 +51,13 @@ There's also the following key-bindings (tweak Default.sublime-keymaps to change
       |alt+d,alt+s|Run the Clang static analyzer on the current file|
       |alt+d,alt+o|Run the Clang static analyzer on the current project|
 
+=== Notes ===
+
+If you experience choppy typing it might be because you sources are too large for clang to be efficiently queried for completion at each typed character. To improve the situation you can either:
+  * Toggle SublimeClang's vs. Sublime Text's completion when you don't need it using alt+d,alt+t
+  * Set "auto_complete": false in the editor's preferences.\\
+    You then lose the automatic as-you-type completion and have to trigger it manually. SublimeClang will still show you the completion menu automatically when you type "." or "->".
+
 === Show your support ===
 
 [[https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=UPSEP2BHMLYEW|Donate]]


### PR DESCRIPTION
I'm not sure if this is wanted but I think it can be worth sharing in the README, it wasn't obvious to me.

After seeing an usual 300-900ms for completion I did a bit of research on why it's slow and how others IDEs/editors are using completion.
I ended up concluding that setting auto_complete to false in Sublime Text's settings is the best compromise for my needs.
