### PR TITLE
Add ${this_file_path} token replacement in configuration values for relative paths

### DIFF
--- a/SublimeClang.sublime-settings
+++ b/SublimeClang.sublime-settings
@@ -184,9 +184,12 @@
     //
     // ${folder:} is replaced with the dirname of the given path.
     // Example: ${folder:/path/to/file} is replaced with "/path/to".
+    // 
+    // ${this_file_path} is replaced by the path to currently edited file.
+    // Example: ${this_file_path} is replaced with "/path/to" when edited file is "/path/to/file".
     //
     // Replacement is done sequentially, first all ${project_path:} are resolved, then ${home} and
-    // ${env:<variable>} tokens,  and then the ${folder:} are replaced,
+    // ${env:<variable>} tokens,  and the ${folder:} are replaced, and then the ${this_file_path}.
     //
     // So for example, you might specify:
     //       "-I${folder:${project_path:main.cpp}}",

--- a/common.py
+++ b/common.py
@@ -100,10 +100,12 @@ try:
                 for path in [os.path.join(f, m.group('file'))] \
                 if os.path.exists(path) \
             ]
+        view = window.active_view()
         value = re.sub(r'\${project_path:(?P<file>[^}]+)}', lambda m: len(get_existing_files(m)) > 0 and get_existing_files(m)[0] or m.group('file'), value)
         value = re.sub(r'\${env:(?P<variable>[^}]+)}', lambda m: os.getenv(m.group('variable')) if os.getenv(m.group('variable')) else "%s_NOT_SET" % m.group('variable'), value)
         value = re.sub(r'\${home}', os.getenv('HOME') if os.getenv('HOME') else "HOME_NOT_SET", value)
         value = re.sub(r'\${folder:(?P<file>[^}]+)}', lambda m: os.path.dirname(m.group('file')), value)
+        value = re.sub(r'\${this_file_path}', os.path.dirname(view.file_name()) if view.file_name() else "FILE_NOT_ON_DISK", value)
         value = value.replace('\\', '/')
 
         return value


### PR DESCRIPTION
Token ${this_file_path}  will be replaced to file path of the file in the current view.

I am working on project, where the next file structure is really common:

```
component_dir/
    private/
        Component.cpp
    Component.hpp
```

So, if I use `#include "Componen.hpp"` in cpp-file, sublime clang will fail to find header file.
As all my tries to use "-I.." in settings were unsuccessful, I have had to implement new token for settings to resolve this problem.
