### PR TITLE
GoTo Implementation fix. 

### DIFF
--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -203,29 +203,10 @@ class ClangGotoImplementation(sublime_plugin.TextCommand):
                         cursor.kind == cindex.CursorKind.CONSTRUCTOR or \
                         cursor.kind == cindex.CursorKind.DESTRUCTOR:
                     f = cursor.location.file.name
-                    clsName = cursor.get_usr()
-                    clsName = "%s" % (clsName[:clsName.rfind("@F@")])
-                    clsName = "%s" % (clsName[clsName.rfind("@")+1:])
                     if f.endswith(".h"):
-                        endings = [".cpp", ".c", ".cc", ".m", ".mm"]
-                        files = []
+                        endings = ["cpp", "c", "cc", "m", "mm"]
                         for ending in endings:
                             f = "%s.%s" % (f[:f.rfind(".")], ending)
-                            files.append(f)
-                        window = self.view.window()
-                        dirs = window.folders()
-                        for dirpath in dirs:
-                            dirpath = os.path.abspath(dirpath)
-                            for dirpath, dirnames, filenames in os.walk(dirpath):
-                                for filepath in filenames:
-                                    if filepath.find(clsName) > -1:
-                                        pth = os.path.join(dirpath, filepath)
-                                        pth = os.path.realpath(os.path.abspath(pth))
-                                        if pth not in files:
-                                            for ending in endings:
-                                                if pth.endswith(ending):
-                                                    files.append(pth)       
-                        for f in files:
                             if f != view.file_name() and os.access(f, os.R_OK):
                                 tu2 = get_translation_unit(view, f, True)
                                 if tu2 == None:
@@ -242,15 +223,13 @@ class ClangGotoImplementation(sublime_plugin.TextCommand):
                                             target = format_cursor(d)
                                             break
                                 finally:
-                                    tu2.unlock()  
+                                    tu2.unlock()
         finally:
             tu.unlock()
         if len(target) > 0:
             open(self.view, target)
         else:
             sublime.status_message("Don't know where the implementation is!")
-
-
 
     def is_enabled(self):
         return is_supported_language(sublime.active_window().active_view())

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -206,6 +206,9 @@ class ClangGotoImplementation(sublime_plugin.TextCommand):
                     if f.endswith(".h"):
                         endings = [".cpp", ".c", ".cc", ".m", ".mm"]
                         files = []
+                        for ending in endings:
+                            f = "%s.%s" % (f[:f.rfind(".")], ending)
+                            files.append(f)
                         window = self.view.window()
                         dirs = window.folders()
                         for dirpath in dirs:

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -203,6 +203,9 @@ class ClangGotoImplementation(sublime_plugin.TextCommand):
                         cursor.kind == cindex.CursorKind.CONSTRUCTOR or \
                         cursor.kind == cindex.CursorKind.DESTRUCTOR:
                     f = cursor.location.file.name
+                    clsName = cursor.get_usr()
+                    clsName = "%s" % (clsName[:clsName.rfind("@F@")])
+                    clsName = "%s" % (clsName[clsName.rfind("@")+1:])
                     if f.endswith(".h"):
                         endings = [".cpp", ".c", ".cc", ".m", ".mm"]
                         files = []
@@ -215,12 +218,13 @@ class ClangGotoImplementation(sublime_plugin.TextCommand):
                             dirpath = os.path.abspath(dirpath)
                             for dirpath, dirnames, filenames in os.walk(dirpath):
                                 for filepath in filenames:
-                                    pth = os.path.join(dirpath, filepath)
-                                    pth = os.path.realpath(os.path.abspath(pth))
-                                    if pth not in files:
-                                        for ending in endings:
-                                            if pth.endswith(ending):
-                                                files.append(pth)       
+                                    if filepath.find(clsName) > -1:
+                                        pth = os.path.join(dirpath, filepath)
+                                        pth = os.path.realpath(os.path.abspath(pth))
+                                        if pth not in files:
+                                            for ending in endings:
+                                                if pth.endswith(ending):
+                                                    files.append(pth)       
                         for f in files:
                             if f != view.file_name() and os.access(f, os.R_OK):
                                 tu2 = get_translation_unit(view, f, True)
@@ -245,6 +249,7 @@ class ClangGotoImplementation(sublime_plugin.TextCommand):
             open(self.view, target)
         else:
             sublime.status_message("Don't know where the implementation is!")
+
 
 
     def is_enabled(self):


### PR DESCRIPTION
Fixes:

1- Now looks into all files in open folders with suitable endings. 
2- Constructor and destructor implementations are also included.

Additional comments:

1- (lines 207-238 in sublimeclang.py)
Currently, the files in all open folders are indexed at every call to the 'GoTo Implementation' function. I admit that this could have been done in a smarter way. May be indexing all files in open folders at the very beginning when the plugin is warming up, and updating the list when only a new folder is open and a new file is added to one of the open folders. However, I aimed for minimum intrusion to your code. I am willing to continue working on making this better. Let me know your thoughts. 

2- (lines 201-204 in sublimeclang.py)
Previously, only methods and function declarations were working, now I added the constructor and destructor definitions.
