### PR TITLE
Adding syntax highlighting to SublimeClang's output panel

### DIFF
--- a/ErrorPanel.JSON-tmLanguage
+++ b/ErrorPanel.JSON-tmLanguage
@@ -1,0 +1,21 @@
+{ 
+  "name": "SublimeClangErrorPanel",
+  "scopeName": "text.sublimeclang",
+  "fileTypes": [],
+  "patterns": 
+  [
+	  	{ 	
+        "match": "^.* - Warning -.*$",
+	  		"name": "string.quoted.double.c",
+	  		"comment": "Warnings"
+		  },
+
+      {   
+        "match": "^.* - Error -.*$",
+        "name": "keyword.control.c",
+        "comment": "Errors"
+      }
+  ],
+ 
+  "uuid": "6e3ddaba-4ad6-4d1b-a7a0-3908b0796e19"
+}

--- a/ErrorPanel.tmLanguage
+++ b/ErrorPanel.tmLanguage
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+	</array>
+	<key>name</key>
+	<string>SublimeClangErrorPanel</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>comment</key>
+			<string>Warnings</string>
+			<key>match</key>
+			<string>^.* - Warning -.*$</string>
+			<key>name</key>
+			<string>string.quoted.double.c</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Errors</string>
+			<key>match</key>
+			<string>^.* - Error -.*$</string>
+			<key>name</key>
+			<string>keyword.control.c</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>text.sublimeclang</string>
+	<key>uuid</key>
+	<string>6e3ddaba-4ad6-4d1b-a7a0-3908b0796e19</string>
+</dict>
+</plist>

--- a/SublimeClang.sublime-settings
+++ b/SublimeClang.sublime-settings
@@ -53,6 +53,12 @@
     // to refresh its contents
     "update_output_panel": true,
 
+    // Whether to apply a tmLanguage syntax file to the output panel
+    "output_panel_use_syntax_file": true,
+
+    // Specify syntax file for output panel
+    "output_panel_syntax_file": "Packages/SublimeClang/ErrorPanel.tmLanguage",
+
     // Whether or not to show the clang parser status in the status bar
     "show_status": true,
 

--- a/errormarkers.py
+++ b/errormarkers.py
@@ -92,6 +92,10 @@ class ClangErrorPanel(object):
         if not self.is_visible(window):
             self.view = window.get_output_panel("clang")
             self.view.settings().set("result_file_regex", "^(.+):([0-9]+),([0-9]+)")
+            if get_setting("output_panel_use_syntax_file", False):
+                fileName = get_setting("output_panel_syntax_file", None)
+                if fileName is not None:
+                    self.view.set_syntax_file(fileName)            
         self.flush()
 
         window.run_command("show_panel", {"panel": "output.clang"})


### PR DESCRIPTION
In regards to issue #66:

With this change, warnings will appear yellow and errors red.

I am not sure if I did the definition of the language file right,
but it seems to work.
