### PR TITLE
Add support for compilation database generated by CMake.

### DIFF
--- a/SublimeClang.sublime-settings
+++ b/SublimeClang.sublime-settings
@@ -270,6 +270,8 @@
         "-Wall"
     ],
 
+    "compilation_database": "${project_path:build/debug/compile_commands.json}",
+
     // A command that can be run to fetch actual options for a source file in a build system.
     // The script should print on stdout a list of space or newline separated options
     // that will be appended to the static list in "options".

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -65,7 +65,7 @@ def get_translation_unit(view, filename=None, blocking=False):
         elif stat == translationunitcache.TranslationUnitCache.STATUS_PARSING:
             sublime.status_message("Hold your horses, cache still warming up")
             return None
-    return translationunitcache.tuCache.get_translation_unit(filename, translationunitcache.tuCache.get_opts(view), translationunitcache.tuCache.get_opts_script(view))
+    return translationunitcache.tuCache.get_translation_unit(filename, translationunitcache.tuCache.get_opts(view, filename), translationunitcache.tuCache.get_opts_script(view))
 
 navigation_stack = []
 clang_complete_enabled = True


### PR DESCRIPTION
The compilation database file name (usually <build folder>/compilation_commands.json) can
be automatically generated by CMake, when generating the makefiles, by setting the CMake
variable CMAKE_EXPORT_COMPILE_COMMANDS to 1. This can be done from inside the CMakeLists.txt
or from the command line. Then, the compilation database can be provided to SublimeClang
using the "compilation_database" parameter in the SublimeClang configuration.

The compilation database format is specified by the LLVM/Clang project:
http://clang.llvm.org/docs/JSONCompilationDatabase.html

The file contains, for each source file built, the complete command line used to built it, which
allows then SublimeClang to have the exact flags to use to parse the file, without having to
add all the include folders manually for each project.

The parsing of each command line is currently done using a regex, which tries to match any
option starting with -D, -I, -O, -U, -W, -f, -g, or -s. This is not ideal, and shlex python
module could be used instead to have a more clean split of the arguments, but it's much
faster to parse the database using this regex.

Also, the database parsing is currently done asynchronously, when the first source file is loaded.
This might be improved by doing it the earliest possible.
