### PR TITLE
Support simple ${project_path} syntax in options

### DIFF
--- a/SublimeClang.sublime-settings
+++ b/SublimeClang.sublime-settings
@@ -188,7 +188,9 @@
     //
     // ${env:<variable>} is replaced with the "variable" environment variable.
     //
-    // ${project_path} returns the directory of the project for the current file or current window.
+    // ${project_path} returns the directory of the project for the current file or current window. In
+    // Sublime Text 2 where no associated project information available, the first folder containing a
+    // sublime-project file opened will be chosen.
     //
     // ${project_path:} tries to find a file with the given name in all the registered project folders and
     // returns the first file found, or the original file name if none is found.

--- a/SublimeClang.sublime-settings
+++ b/SublimeClang.sublime-settings
@@ -181,11 +181,14 @@
     // so to make them take effect you'll have to clear the cache first. The
     // default keybinding for clearing the cache is alt+d,alt+c.
     //
-    // ${home}, ${env:<variable>}, ${project_path:} and ${folder:} tokens can be used in these options.
+    // ${home}, ${env:<variable>}, ${project_path}, ${project_path:} and ${folder:} tokens can be
+    // used in these options.
     //
     // ${home} is replaced with the value of the HOME environment variable.
     //
     // ${env:<variable>} is replaced with the "variable" environment variable.
+    //
+    // ${project_path} returns the directory of the project for the current file or current window.
     //
     // ${project_path:} tries to find a file with the given name in all the registered project folders and
     // returns the first file found, or the original file name if none is found.

--- a/internals/common.py
+++ b/internals/common.py
@@ -148,6 +148,7 @@ try:
                 if os.path.exists(path) \
             ]
         view = window.active_view()
+        value = re.sub(r'\${project_path}', os.path.split(window.project_file_name())[0], value)
         value = re.sub(r'\${project_path:(?P<file>[^}]+)}', lambda m: len(get_existing_files(m)) > 0 and get_existing_files(m)[0] or m.group('file'), value)
         value = re.sub(r'\${env:(?P<variable>[^}]+)}', lambda m: os.getenv(m.group('variable')) if os.getenv(m.group('variable')) else "%s_NOT_SET" % m.group('variable'), value)
         value = re.sub(r'\${home}', re.escape(os.getenv('HOME')) if os.getenv('HOME') else "HOME_NOT_SET", value)

--- a/internals/common.py
+++ b/internals/common.py
@@ -30,6 +30,7 @@ except:
 import os
 import re
 import sys
+import glob
 
 if sys.version[0] == '2':
     def sencode(s):
@@ -148,7 +149,17 @@ try:
                 if os.path.exists(path) \
             ]
         view = window.active_view()
-        value = re.sub(r'\${project_path}', os.path.split(window.project_file_name())[0], value)
+        project_path = None
+        if hasattr(window, "project_file_name"):
+            project_path = os.path.split(window.project_file_name())[0]
+        else:
+            for f in window.folders():
+                projects = glob.glob(os.path.join(f, '*.sublime-project'))
+                if len(projects):
+                    project_path = f
+                    break
+        if project_path:
+            value = re.sub(r'\${project_path}', project_path, value)
         value = re.sub(r'\${project_path:(?P<file>[^}]+)}', lambda m: len(get_existing_files(m)) > 0 and get_existing_files(m)[0] or m.group('file'), value)
         value = re.sub(r'\${env:(?P<variable>[^}]+)}', lambda m: os.getenv(m.group('variable')) if os.getenv(m.group('variable')) else "%s_NOT_SET" % m.group('variable'), value)
         value = re.sub(r'\${home}', re.escape(os.getenv('HOME')) if os.getenv('HOME') else "HOME_NOT_SET", value)


### PR DESCRIPTION
Simple ${project_path} can be convenient for per-project options like:

```
"sublimeclang_options":
[
  "-I${project_path}/../../../../build/texk",
  "-I${project_path}/../../../../build/texk/web2c",
  "-I${project_path}/../..",
  "-I${project_path}/.."
]
```

It's simpler to specify than more versatile ${project_path:filename} syntax.
