### PR TITLE
Fix for working with python3 (ST3)

### DIFF
--- a/internals/translationunitcache.py
+++ b/internals/translationunitcache.py
@@ -26,7 +26,8 @@ import sys
 
 from .common import Worker, complete_path, expand_path, get_setting, get_path_setting,\
                     get_language, LockedVariable, run_in_main_thread, error_message,\
-                    display_user_selection, get_cpu_count, status_message, bencode, bdecode, are_we_there_yet
+                    display_user_selection, get_cpu_count, status_message, bencode, bdecode,\
+                    sencode, sdecode, are_we_there_yet
 from .clang import cindex
 from .parsehelp.parsehelp import *
 

--- a/internals/translationunitcache.py
+++ b/internals/translationunitcache.py
@@ -1251,14 +1251,14 @@ class TranslationUnitCache(Worker):
 
             if opts_script:
                 # shlex.split barfs if fed with an unicode strings
-                args = shlex.split(opts_script.encode()) + [filename]
+                args = shlex.split(sencode(opts_script)) + [filename]
                 process = subprocess.Popen(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
                 output = process.communicate()
                 if process.returncode:
                     print("The options_script failed with code [%s]" % process.returncode)
                     print(output[1])
                 else:
-                    opts += shlex.split(output[0])
+                    opts += shlex.split(bdecode(output[0]))
 
             if self.debug_options:
                 print("Will compile file %s with the following options:\n%s" % (filename, opts))


### PR DESCRIPTION
shlex.split cannot handle bytes, and since python3 does not ignore anymore the b prefix of the strings (to the contrary of python 2.x), shlex.split will fail like this:
....
   opts += shlex.split(output[0])
  File "X/shlex.py", line 276, in split
  File "X/shlex.py", line 266, in **next**
  File "X/shlex.py", line 93, in get_token
  File "X/shlex.py", line 121, in read_token
AttributeError: 'bytes' object has no attribute 'read'

Thus it's required to decode the string.
