### PR TITLE
Fix for plugin loading on ST3 + Windows

### DIFF
--- a/internals/common.py
+++ b/internals/common.py
@@ -160,6 +160,17 @@ try:
     def display_user_selection(options, callback):
         sublime.active_window().show_quick_panel(options, callback)
 
+    def look_for_file(filename, current_dir, levels_up):
+        """Look for file up to #levels_up dir levels, starting from #current_dir."""
+        while current_dir != os.path.dirname(current_dir):
+            if os.path.exists(os.path.join(current_dir, filename)):
+                return os.path.join(current_dir, filename)
+            if levels_up <= 0:
+                break
+            levels_up -= 1
+            current_dir = os.path.dirname(current_dir)
+        return None
+
 except:
     # Just used for unittesting
     def are_we_there_yet(f):
@@ -185,6 +196,9 @@ except:
 
     def display_user_selection(options, callback):
         callback(0)
+
+    def loof_for_file(filename, current_dir, levels_up):
+        return None
 
 
 class LockedVariable:

--- a/internals/common.py
+++ b/internals/common.py
@@ -197,7 +197,7 @@ except:
     def display_user_selection(options, callback):
         callback(0)
 
-    def loof_for_file(filename, current_dir, levels_up):
+    def look_for_file(filename, current_dir, levels_up):
         return None
 
 

--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -43,7 +43,7 @@ try:
     from internals import translationunitcache
     from internals.parsehelp import parsehelp
     plugin_loaded()
-except:
+except ImportError:
     import queue as Queue
     from .internals.clang import cindex
     from .errormarkers import clear_error_marks, add_error_mark, show_error_marks, \


### PR DESCRIPTION
In ST3, the script path is of the included module, in ST2 (Python2?) the path
is relative to the includee. Make the loading logic more flexible by looking
up 3 directories up from the current one, looking for the plugin.
