### PR TITLE
Fix misbehaving caret movement with multiple cursors.

### DIFF
--- a/sublimeclang.py
+++ b/sublimeclang.py
@@ -346,7 +346,7 @@ class ClangComplete(sublime_plugin.TextCommand):
     def run(self, edit, characters):
         regions = [a for a in self.view.sel()]
         self.view.sel().clear()
-        for region in regions:
+        for region in reversed(regions):
             pos = 0
             region.end() + len(characters)
             if region.size() > 0:
@@ -439,10 +439,10 @@ class SublimeClangAutoComplete(sublime_plugin.EventListener):
                 except:
                     traceback.print_exc()
             if cached_results != None:
-                print("found fast completions")
+                # print("found fast completions")
                 ret = cached_results
             else:
-                print("doing slow completions")
+                # print("doing slow completions")
                 row, col = view.rowcol(locations[0] - len(prefix))
                 unsaved_files = []
                 if view.is_dirty():


### PR DESCRIPTION
With multiple regions, we need to modify them front-to-back as otherwise
modifications in preceding regions will affect cursor postiion when modifying
following ones. The regions seem to be always sorted by the position in the
document so we shouldn't need more sophisticated logic.

Also disable some debugging print's.
