### PR TITLE
Fix bug when opening single files in ST3

### DIFF
--- a/internals/common.py
+++ b/internals/common.py
@@ -150,7 +150,7 @@ try:
             ]
         view = window.active_view()
         project_path = None
-        if hasattr(window, "project_file_name"):
+        if hasattr(window, "project_file_name") and window.project_file_name() is not None:
             project_path = os.path.split(window.project_file_name())[0]
         else:
             for f in window.folders():


### PR DESCRIPTION
There was a little problem with [this pull request](https://github.com/quarnster/SublimeClang/pull/207) when opening single files in ST3. When no project is opened,  `window.project_file_name()` returns `None` and therefore, `os.path.split` throws 

``` python
AttributeError: 'NoneType' object has no attribute 'rfind'
```

Just added a little condition to avoid the plugin to crash.

Anyway, thanks for all the good work! 
I hope I'll be able to take some time to help with your completion project soon.
